### PR TITLE
Fixes type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,8 +2,8 @@ declare module 'athena-express-plus' {
     import { S3 } from '@aws-sdk/client-s3';
     import { Athena } from '@aws-sdk/client-athena';
     interface ConnectionConfigInterface {
-        s3: typeof S3;
-        athena: typeof Athena,
+        s3: S3;
+        athena: Athena,
         s3Bucket: string;
         getStats: boolean;
         db: string,


### PR DESCRIPTION
S3, Athena is a class, so instances created with new do not use the typeof operator.
https://www.typescriptlang.org/docs/handbook/2/typeof-types.html
