### PR TITLE
Fixed concurrent querying with cached s3Metadata

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -3,7 +3,6 @@
 
 const readline = require("readline"),
   csv = require("csvtojson");
-let s3Metadata = null;
 
 function startQueryExecution(config) {
   const params = {
@@ -50,10 +49,6 @@ function checkIfExecutionCompleted(config) {
         });
         if (data.QueryExecution.Status.State === "SUCCEEDED") {
           retry = config.retry;
-          s3Metadata = config.athena.getQueryResults({
-            QueryExecutionId: config.QueryExecutionId,
-            MaxResults: 1,
-          });
           resolve(data);
         } else if (data.QueryExecution.Status.State === "FAILED") {
           reject(data.QueryExecution.Status.StateChangeReason);
@@ -101,7 +96,7 @@ async function getQueryResultsFromS3(params) {
     );
     if (params.config.formatJson) {
       return {
-        items: await cleanUpPaginatedDML(queryResults, paginationFactor),
+        items: await cleanUpPaginatedDML(queryResults, paginationFactor, params.config),
         nextToken: queryResults.NextToken,
       };
     } else {
@@ -123,8 +118,8 @@ async function getQueryResultsFromS3(params) {
   }
 }
 
-async function cleanUpPaginatedDML(queryResults, paginationFactor) {
-  const dataTypes = await getDataTypes();
+async function cleanUpPaginatedDML(queryResults, paginationFactor, params) {
+  const dataTypes = await getDataTypes(params);
   const columnNames = Object.keys(dataTypes).reverse();
   let rowObject = {};
   let unformattedS3RowArray = null;
@@ -161,8 +156,12 @@ function getRawResultsFromS3(input) {
   });
 }
 
-function getDataTypes() {
+function getDataTypes(config) {
   return new Promise(async function (resolve) {
+    const s3Metadata = config.athena.getQueryResults({
+      QueryExecutionId: config.QueryExecutionId,
+      MaxResults: 1,
+    });
     const columnInfoArray = (await s3Metadata).ResultSet.ResultSetMetadata
       .ColumnInfo;
     let columnInfoArrayLength = columnInfoArray.length;
@@ -178,7 +177,7 @@ function getDataTypes() {
 
 async function cleanUpDML(input, params) {
   let cleanJson = [];
-  const dataTypes = await getDataTypes();
+  const dataTypes = await getDataTypes(params);
   return new Promise(function (resolve) {
     input.pipe(
       csv({


### PR DESCRIPTION
When performing multiple concurrent queries with this package, the output is not formatted correctly, meaning `addDataType` does not cast the values properly and leave them as `string`.

This is because `s3Metadata` is cached in `helper.js`, even though it doesn't need to be, which means it can be overwritten when multiple queries are executing concurrently resulting in incorrect metadata being used for converting query results.

---

For example, when running these 2 queries at/around the same time

```
-- query 1 - name is string, contact_no is number
SELECT name, contact_no FROM table1 ...

-- query 2 - rating is number, address is string
SELECT rating, address FROM table2 ...
```

There can be a race condition on whichever query sets `s3Metadata` later, and that later set `s3Metadata` is used when formatting the results for both queries, which can result in

```
{
  name: 'John'
  contact_no: '222' // this should have been converted into a number
}
{
  rating: 5
  address: 'Australia'
}

or

{
  name: 'John'
  contact_no: 222
}
{
  rating: '5' // this should have been converted into a number
  address: 'Australia'
}
```

---

This PR fixes this issue by 1) specifying the `s3Metadata` query right before it is used, 2) not caching `s3Metadata` in the file

- This results in exactly the same behaviour as before, when the client is executing a single query
- And for concurrent queries, `s3Metadata` is isolated from the diff queries and won't overwrite the other
