### PR TITLE
feat: use modular AWS SDK v3

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,9 @@
 declare module 'athena-express-plus' {
-    import { S3 } from '@aws-sdk/client-s3';
-    import { Athena } from '@aws-sdk/client-athena';
+    import { S3Client } from '@aws-sdk/client-s3';
+    import { AthenaClient } from '@aws-sdk/client-athena';
     interface ConnectionConfigInterface {
-        s3: S3;
-        athena: Athena,
+        s3: S3Client;
+        athena: AthenaClient;
         s3Bucket: string;
         getStats: boolean;
         db: string,

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,8 +1,10 @@
 "use strict";
 //helpers.js
 
-const readline = require("readline"),
-  csv = require("csvtojson");
+const { GetQueryExecutionCommand, GetQueryResultsCommand, StartQueryExecutionCommand } = require("@aws-sdk/client-athena");
+const { GetObjectCommand } = require("@aws-sdk/client-s3");
+const csv = require("csvtojson");
+const readline = require("readline");
 
 function startQueryExecution(config) {
   const params = {
@@ -25,7 +27,7 @@ function startQueryExecution(config) {
   return new Promise(function (resolve, reject) {
     const startQueryExecutionRecursively = async function () {
       try {
-        const data = await config.athena.startQueryExecution(params);
+        const data = await config.athena.send(new StartQueryExecutionCommand(params));
         resolve(data.QueryExecutionId);
       } catch (err) {
         isCommonAthenaError(err.code)
@@ -44,9 +46,9 @@ function checkIfExecutionCompleted(config) {
   return new Promise(function (resolve, reject) {
     const keepCheckingRecursively = async function () {
       try {
-        const data = await config.athena.getQueryExecution({
+        const data = await config.athena.send(new GetQueryExecutionCommand({
           QueryExecutionId: config.QueryExecutionId,
-        });
+        }));
         if (data.QueryExecution.Status.State === "SUCCEEDED") {
           retry = config.retry;
           resolve(data);
@@ -77,7 +79,7 @@ async function getQueryResultsFromS3(params) {
   };
 
   if (params.statementType === "UTILITY" || params.statementType === "DDL") {
-    const input = await params.config.s3.getObject(s3Params);
+    const input = await params.config.s3.send(new GetObjectCommand(s3Params));
     return { items: await cleanUpNonDML(input.Body) };
   } else if (Boolean(params.config.pagination)) {
     //user wants DML response paginated
@@ -91,9 +93,9 @@ async function getQueryResultsFromS3(params) {
     };
 
     
-    const queryResults = await params.config.athena.getQueryResults(
+    const queryResults = await params.config.athena.send(new GetQueryResultsCommand(
       paginationParams
-    );
+    ));
     if (params.config.formatJson) {
       return {
         items: await cleanUpPaginatedDML(queryResults, paginationFactor, params.config),
@@ -107,7 +109,7 @@ async function getQueryResultsFromS3(params) {
     }
   } else {
     //user doesn't want DML response paginated
-    const input = await params.config.s3.getObject(s3Params);
+    const input = await params.config.s3.send(new GetObjectCommand(s3Params));
     if (params.config.formatJson) {
       return {
         items: await cleanUpDML(input.Body, params.config),
@@ -158,10 +160,10 @@ function getRawResultsFromS3(input) {
 
 function getDataTypes(config) {
   return new Promise(async function (resolve) {
-    const s3Metadata = config.athena.getQueryResults({
+    const s3Metadata = config.athena.send(new GetQueryResultsCommand({
       QueryExecutionId: config.QueryExecutionId,
       MaxResults: 1,
-    });
+    }));
     const columnInfoArray = (await s3Metadata).ResultSet.ResultSetMetadata
       .ColumnInfo;
     let columnInfoArrayLength = columnInfoArray.length;


### PR DESCRIPTION
This is a non breaking change because S3 extends S3Client, and Athena extends AthenaClient, so the `send` method is available in both classes

Fixes #22