### PR TITLE
fix: Track 3rd party libraries used in library code as regular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "athena-express-plus",
-  "version": "8.0.5",
+  "version": "8.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "athena-express-plus",
-      "version": "8.0.5",
+      "version": "8.0.10",
       "license": "MIT",
       "dependencies": {
+        "@aws-sdk/client-athena": "^3.414.0",
+        "@aws-sdk/client-s3": "^3.414.0",
         "csvtojson": "^2.0.10"
       },
       "devDependencies": {
-        "@aws-sdk/client-athena": "^3.414.0",
-        "@aws-sdk/client-s3": "^3.414.0",
         "chai": "^4.2.0",
         "coveralls": "^3.0.11",
         "istanbul": "^0.4.5",
@@ -25,7 +25,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
       "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -35,14 +34,12 @@
     "node_modules/@aws-crypto/crc32/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/crc32c": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz",
       "integrity": "sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -52,14 +49,12 @@
     "node_modules/@aws-crypto/crc32c/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/ie11-detection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
       "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-      "dev": true,
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -67,14 +62,12 @@
     "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha1-browser": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-3.0.0.tgz",
       "integrity": "sha512-NJth5c997GLHs6nOYTzFKTbYdMNA6/1XlKVgnZoaZcQ7z7UJlOgj2JdbHE8tiYLS3fzXNCguct77SPGat2raSw==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/ie11-detection": "^3.0.0",
         "@aws-crypto/supports-web-crypto": "^3.0.0",
@@ -88,14 +81,12 @@
     "node_modules/@aws-crypto/sha1-browser/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
       "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/ie11-detection": "^3.0.0",
         "@aws-crypto/sha256-js": "^3.0.0",
@@ -110,14 +101,12 @@
     "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha256-js": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
       "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -127,14 +116,12 @@
     "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
       "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -142,14 +129,12 @@
     "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/util": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
       "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -159,14 +144,12 @@
     "node_modules/@aws-crypto/util/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/client-athena": {
       "version": "3.414.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-athena/-/client-athena-3.414.0.tgz",
       "integrity": "sha512-0UpjwvntiVxJ9s85UdJeQ5Hx6Y/6A59dGtI6GOOrm0vTaKIKhGJ6MU1qaC2O4EuANm6hliLxMTA3e7sIEUAKww==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -215,7 +198,6 @@
       "version": "3.414.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.414.0.tgz",
       "integrity": "sha512-uEag2GPuuxWmnzOxUhAy0EYo3LW3u/UyCw1IxU3zkaTRQnD6TZ07kjv3Q6Zytqt82yKzJPZInzNNRdtGJdyxbw==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "3.0.0",
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -281,7 +263,6 @@
       "version": "3.414.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.414.0.tgz",
       "integrity": "sha512-GvRwQ7wA3edzsQEKS70ZPhkOUZ62PAiXasjp6GxrsADEb8sV1z4FxXNl9Un/7fQxKkh9QYaK1Wu1PmhLi9MLMg==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -326,7 +307,6 @@
       "version": "3.414.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.414.0.tgz",
       "integrity": "sha512-xeYH3si6Imp1EWolWn1zuxJJu2AXKwXl1HDftQULwC5AWkm1mNFbXYSJN4hQul1IM+kn+JTRB0XRHByQkKhe+Q==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -375,7 +355,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.413.0.tgz",
       "integrity": "sha512-yeMOkfG20/RlzfPMtQuDB647AcPEvFEVYOWZzAWVJfldYQ5ybKr0d7sBkgG9sdAzGkK3Aw9dE4rigYI8EIqc1Q==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/property-provider": "^2.0.0",
@@ -390,7 +369,6 @@
       "version": "3.414.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.414.0.tgz",
       "integrity": "sha512-rlpLLx70roJL/t40opWC96LbIASejdMbRlgSCRpK8b/hKngYDe5A7SRVacaw08vYrAywxRiybxpQOwOt9b++rA==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.413.0",
         "@aws-sdk/credential-provider-process": "3.413.0",
@@ -411,7 +389,6 @@
       "version": "3.414.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.414.0.tgz",
       "integrity": "sha512-xlkcOUKeGHInxWKKrZKIPSBCUL/ozyCldJBjmMKEj7ZmBAEiDcjpMe3pZ//LibMkCSy0b/7jtyQBE/eaIT2o0A==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.413.0",
         "@aws-sdk/credential-provider-ini": "3.414.0",
@@ -433,7 +410,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.413.0.tgz",
       "integrity": "sha512-GFJdgS14GzJ1wc2DEnS44Z/34iBZ05CAkvDsLN2CMwcDgH4eZuif9/x0lwzIJBK3xVFHzYUeVvEzsqRPbCHRsw==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/property-provider": "^2.0.0",
@@ -449,7 +425,6 @@
       "version": "3.414.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.414.0.tgz",
       "integrity": "sha512-w9g2hlkZn7WekWICRqk+L33py7KrjYMFryVpkKXOx2pjDchCfZDr6pL1ml782GZ0L3qsob4SbNpbtp13JprnWQ==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/client-sso": "3.414.0",
         "@aws-sdk/token-providers": "3.413.0",
@@ -467,7 +442,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.413.0.tgz",
       "integrity": "sha512-5cdA1Iq9JeEHtg59ERV9fdMQ7cS0JF6gH/BWA7HYEUGdSVPXCuwyEggPtG64QgpNU7SmxH+QdDG+Ldxz09ycIA==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/property-provider": "^2.0.0",
@@ -482,7 +456,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.413.0.tgz",
       "integrity": "sha512-hHfaKg4rbpdgB6iMNLW/ubAJFsPFMNOV/hHpZ7BJVdA05fW6Zj6es+TSr7DM3j4Dv49ckhWY0P+JrSkM3FXXpg==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.413.0",
         "@aws-sdk/util-arn-parser": "3.310.0",
@@ -500,7 +473,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.413.0.tgz",
       "integrity": "sha512-14L4Fit+3EEVZNHCZKxua4vCrh+dGaaDfC5Ng3A8nILAqCsG2dhbDbUOwbnAaM8MCEVOgZS/NwUUlLA9AZfKgQ==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/protocol-http": "^3.0.3",
@@ -515,7 +487,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.413.0.tgz",
       "integrity": "sha512-xb7WIxmyCQoBCnzaN+Widuan0PbNxYegKLOW4XheYz/v7lBEttIcGMu+OIAIQs3KlTb3dx8jqjSj2rMNnru8MQ==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
         "@aws-crypto/crc32c": "3.0.0",
@@ -534,7 +505,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.413.0.tgz",
       "integrity": "sha512-r9PQx468EzPHo9wRzZLfgROpKtVdbkteMrdhsuM12bifVHjU1OHr7yfhc1OdWv39X8Xiv6F8n5r+RBQEM0S6+g==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/protocol-http": "^3.0.3",
@@ -549,7 +519,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.413.0.tgz",
       "integrity": "sha512-JecF1O1Lm8ZZtCgXHwJm0ZysVf8K0Z8DbrNMJfYkyfsP3CYuQNJbmjrehyRl7aCuxMJ16EUGdXgoP1M8TImLpA==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/types": "^2.3.1",
@@ -563,7 +532,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.413.0.tgz",
       "integrity": "sha512-jqcXDubcKvoqBy+kkEa0WoNjG6SveDeyNy+gdGnTV+DEtYjkcHrHJei4q0W5zFl0mzc+dP+z8tJF44rv95ZY3Q==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/types": "^2.3.1",
@@ -577,7 +545,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.413.0.tgz",
       "integrity": "sha512-C6k0IKJk/A4/VBGwUjxEPG+WOjjnmWAZVRBUzaeM7PqRh+g5rLcuIV356ntV3pREVxyiSTePTYVYIHU9YXkLKQ==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/protocol-http": "^3.0.3",
@@ -592,7 +559,6 @@
       "version": "3.414.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.414.0.tgz",
       "integrity": "sha512-IKTiYMWN/2HZtgBinrDOGq+gKYkM9h477AqVr7EXSfll+gM9phwJKEitgxje7IaCi8ViQcFKtTRly3eCLX6GIA==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.413.0",
         "@aws-sdk/util-arn-parser": "3.310.0",
@@ -609,7 +575,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.413.0.tgz",
       "integrity": "sha512-t0u//JUyaEZRVnH5q+Ur3tWnuyIsTdwA0XOdDCZXcSlLYzGp2MI/tScLjn9IydRrceIFpFfmbjk4Nf/Q6TeBTQ==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/middleware-signing": "3.413.0",
         "@aws-sdk/types": "3.413.0",
@@ -624,7 +589,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.413.0.tgz",
       "integrity": "sha512-QFEnVvIKYPCermM+ESxEztgUgXzGSKpnPnohMYNvSZySqmOLu/4VvxiZbRO/BX9J3ZHcUgaw4vKm5VBZRrycxw==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/property-provider": "^2.0.0",
@@ -642,7 +606,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.413.0.tgz",
       "integrity": "sha512-MQNksEnhjObNLgE2zRd0OltdijQuqHaArP3FygtdeE2bCXc/D5mCpUX8fgDC5grQIBNdRdaar2YL62UxFsHWrw==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/types": "^2.3.1",
@@ -656,7 +619,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.413.0.tgz",
       "integrity": "sha512-eVMJyeWxNBqerhfD+sE9sTjDtwQiECrfU6wpUQP5fGPhJD2cVVZPxuTuJGDZCu/4k/V61dF85IYlsPUNLdVQ6w==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.413.0",
         "@aws-sdk/util-endpoints": "3.413.0",
@@ -672,7 +634,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.413.0.tgz",
       "integrity": "sha512-h90e6yyOhvoc+1F5vFk3C5mxwB8RSDEMKTO/fxexyur94seczZ1yxyYkTMZv30oc9RUiToABlHNrh/wxL7TZPQ==",
-      "dev": true,
       "dependencies": {
         "@smithy/node-config-provider": "^2.0.10",
         "@smithy/types": "^2.3.1",
@@ -688,7 +649,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.413.0.tgz",
       "integrity": "sha512-4USefVS5HPeJ8Yx0j6l84837adWGTifGpnltD+4mIgvpGp/hW3EkwvJko6i4cnLbeY8D2+8XvgT9YN1LUhvFmg==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/protocol-http": "^3.0.3",
@@ -704,7 +664,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.413.0.tgz",
       "integrity": "sha512-NfP1Ib9LAWVLMTOa/1aJwt4TRrlRrNyukCpVZGfNaMnNNEoP5Rakdbcs8KFVHe/MJzU+GdKVzxQ4TgRkLOGTrA==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -750,7 +709,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.413.0.tgz",
       "integrity": "sha512-j1xib0f/TazIFc5ySIKOlT1ujntRbaoG4LJFeEezz4ji03/wSJMI8Vi4KjzpBp8J1tTu0oRDnsxRIGixsUBeYQ==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
@@ -763,7 +721,6 @@
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.310.0.tgz",
       "integrity": "sha512-jL8509owp/xB9+Or0pvn3Fe+b94qfklc2yPowZZIFAkFcCSIdkIglz18cPDWnYAcy9JGewpMS1COXKIUhZkJsA==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -775,7 +732,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.413.0.tgz",
       "integrity": "sha512-VAwr7cITNb1L6/2XUPIbCOuhKGm0VtKCRblurrfUF2bxqG/wtuw/2Fm4ahYJPyxklOSXAMSq+RHdFWcir0YB/g==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.413.0",
         "tslib": "^2.5.0"
@@ -788,7 +744,6 @@
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
       "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -800,7 +755,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.413.0.tgz",
       "integrity": "sha512-7j/qWcRO2OBZBre2fC6V6M0PAS9n7k6i+VtofPkkhxC2DZszLJElqnooF9hGmVGYK3zR47Np4WjURXKIEZclWg==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/types": "^2.3.1",
@@ -812,7 +766,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.413.0.tgz",
       "integrity": "sha512-vHm9TVZIzfWMeDvdmoOky6VarqOt8Pr68CESHN0jyuO6XbhCDnr9rpaXiBhbSR+N1Qm7R/AfJgAhQyTMu2G1OA==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/node-config-provider": "^2.0.10",
@@ -835,7 +788,6 @@
       "version": "3.259.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
       "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -844,7 +796,6 @@
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.310.0.tgz",
       "integrity": "sha512-TqELu4mOuSIKQCqj63fGVs86Yh+vBx5nHRpWKNUNhB2nPTpfbziTs5c1X358be3peVWA4wPxW7Nt53KIg1tnNw==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -856,7 +807,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.8.tgz",
       "integrity": "sha512-2SOdVj5y0zE37Y9scSXoizoxgi6mgnDabi7a/SOfhl0p+50I0rIkuJTfyAuTPDtQ7e5dD6tSZPCLB3c/YM6Zig==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.3.2",
         "tslib": "^2.5.0"
@@ -869,7 +819,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-2.0.0.tgz",
       "integrity": "sha512-k+J4GHJsMSAIQPChGBrjEmGS+WbPonCXesoqP9fynIqjn7rdOThdH8FAeCmokP9mxTYKQAKoHCLPzNlm6gh7Wg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       }
@@ -878,7 +827,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-2.0.0.tgz",
       "integrity": "sha512-HM8V2Rp1y8+1343tkZUKZllFhEQPNmpNdgFAncbTsxkZ18/gqjk23XXv3qGyXWp412f3o43ZZ1UZHVcHrpRnCQ==",
-      "dev": true,
       "dependencies": {
         "@smithy/util-base64": "^2.0.0",
         "tslib": "^2.5.0"
@@ -888,7 +836,6 @@
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.9.tgz",
       "integrity": "sha512-QBkGPLUqyPmis9Erz8v4q5lo/ErnF7+GD5WZHa6JZiXopUPfaaM+B21n8gzS5xCkIXZmnwzNQhObP9xQPu8oqQ==",
-      "dev": true,
       "dependencies": {
         "@smithy/node-config-provider": "^2.0.11",
         "@smithy/types": "^2.3.2",
@@ -904,7 +851,6 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.11.tgz",
       "integrity": "sha512-uJJs8dnM5iXkn8a2GaKvlKMhcOJ+oJPYqY9gY3CM/EieCVObIDjxUtR/g8lU/k/A+OauA78GzScAfulmFjPOYA==",
-      "dev": true,
       "dependencies": {
         "@smithy/node-config-provider": "^2.0.11",
         "@smithy/property-provider": "^2.0.9",
@@ -920,7 +866,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.8.tgz",
       "integrity": "sha512-onO4to8ujCKn4m5XagReT9Nc6FlNG5vveuvjp1H7AtaG7njdet1LOl6/jmUOkskF2C/w+9jNw3r9Ak+ghOvN0A==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
         "@smithy/types": "^2.3.2",
@@ -932,7 +877,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.0.8.tgz",
       "integrity": "sha512-/RGlkKUnC0sd+xKBKH/2APSBRmVMZTeLOKZMhrZmrO+ONoU+DwyMr/RLJ6WnmBKN+2ebjffM4pcIJTKLNNDD8g==",
-      "dev": true,
       "dependencies": {
         "@smithy/eventstream-serde-universal": "^2.0.8",
         "@smithy/types": "^2.3.2",
@@ -946,7 +890,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.0.8.tgz",
       "integrity": "sha512-EyAEj258eMUv9zcMvBbqrInh2eHRYuiwQAjXDMxZFCyP+JePzQB6O++3wFwjQeRKMFFgZipNgnEXfReII4+NAw==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.3.2",
         "tslib": "^2.5.0"
@@ -959,7 +902,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.0.8.tgz",
       "integrity": "sha512-FMBatSUSKwh6aguKVJokXfJaV8nqsuCkCZHb9MP9zah0ZF+ohbTLeeed7DQGeTVBueVIVWEzIsShPxtxBv7MMQ==",
-      "dev": true,
       "dependencies": {
         "@smithy/eventstream-serde-universal": "^2.0.8",
         "@smithy/types": "^2.3.2",
@@ -973,7 +915,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.0.8.tgz",
       "integrity": "sha512-6InMXH8BUKoEDa6CAuxR4Gn8Gf2vBfVtjA9A6zDKZClYHT+ANUJS+2EtOBc5wECJJGk4KLn5ajQyrt9MBv5lcw==",
-      "dev": true,
       "dependencies": {
         "@smithy/eventstream-codec": "^2.0.8",
         "@smithy/types": "^2.3.2",
@@ -987,7 +928,6 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.1.4.tgz",
       "integrity": "sha512-SL24M9W5ERByoXaVicRx+bj9GJVujDnPn+QO7GY7adhY0mPGa6DSF58pVKsgIh4r5Tx/k3SWCPlH4BxxSxA/fQ==",
-      "dev": true,
       "dependencies": {
         "@smithy/protocol-http": "^3.0.4",
         "@smithy/querystring-builder": "^2.0.8",
@@ -1000,7 +940,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-2.0.8.tgz",
       "integrity": "sha512-IgvRlBMfg/qLg321a59T1yTdEEbaizLrEVsU3DHj65DAO4lFRMF5f+l7vuV+je6m1G9wSD5GQXLturX8qlGb4g==",
-      "dev": true,
       "dependencies": {
         "@smithy/chunked-blob-reader": "^2.0.0",
         "@smithy/chunked-blob-reader-native": "^2.0.0",
@@ -1012,7 +951,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.8.tgz",
       "integrity": "sha512-yZL/nmxZzjZV5/QX5JWSgXlt0HxuMTwFO89CS++jOMMPiCMZngf6VYmtNdccs8IIIAMmfQeTzwu07XgUE/Zd3Q==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.3.2",
         "@smithy/util-buffer-from": "^2.0.0",
@@ -1027,7 +965,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-2.0.8.tgz",
       "integrity": "sha512-82zC6I9ZJycbEZH8TVyXyBx9c2ZIPQDgBvM0x5AFPUl/i1AxwKKX+lwYRnzgkF//cYhIIoJaCfJ9mjSMPRGvCQ==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.3.2",
         "@smithy/util-utf8": "^2.0.0",
@@ -1041,7 +978,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.8.tgz",
       "integrity": "sha512-88VOS7W3KzUz/bNRc+Sl/F/CDIasFspEE4G39YZRHIh9YmsXF7GUyVaAKURfMNulTie62ayk6BHC9O0nOBAVgQ==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.3.2",
         "tslib": "^2.5.0"
@@ -1051,7 +987,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
       "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1063,7 +998,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.0.8.tgz",
       "integrity": "sha512-1VVECXEiuJvjXv+mudiaUFKYwgDLOWz5MTTy8RzbrPiU3GiOb3/o5/urdkYpqmgoMfxdvxxOw/Adjv2dV2q2Yg==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.3.2",
         "@smithy/util-utf8": "^2.0.0",
@@ -1074,7 +1008,6 @@
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.10.tgz",
       "integrity": "sha512-EGSbysyA4jH0p3xI6G0jdXoj9Iz9GUnAta6aEaHtXm3wVWtenRf80y2TeVvNkVSr5jwKOdSCjKIRI2l1A/oZLA==",
-      "dev": true,
       "dependencies": {
         "@smithy/protocol-http": "^3.0.4",
         "@smithy/types": "^2.3.2",
@@ -1088,7 +1021,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.8.tgz",
       "integrity": "sha512-yOpogfG2d2V0cbJdAJ6GLAWkNOc9pVsL5hZUfXcxJu408N3CUCsXzIAFF6+70ZKSE+lCfG3GFErcSXv/UfUbjw==",
-      "dev": true,
       "dependencies": {
         "@smithy/middleware-serde": "^2.0.8",
         "@smithy/types": "^2.3.2",
@@ -1104,7 +1036,6 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.11.tgz",
       "integrity": "sha512-pknfokumZ+wvBERSuKAI2vVr+aK3ZgPiWRg6+0ZG4kKJogBRpPmDGWw+Jht0izS9ZaEbIobNzueIb4wD33JJVg==",
-      "dev": true,
       "dependencies": {
         "@smithy/node-config-provider": "^2.0.11",
         "@smithy/protocol-http": "^3.0.4",
@@ -1123,7 +1054,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.8.tgz",
       "integrity": "sha512-Is0sm+LiNlgsc0QpstDzifugzL9ehno1wXp109GgBgpnKTK3j+KphiparBDI4hWTtH9/7OUsxuspNqai2yyhcg==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.3.2",
         "tslib": "^2.5.0"
@@ -1136,7 +1066,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.1.tgz",
       "integrity": "sha512-UexsfY6/oQZRjTQL56s9AKtMcR60tBNibSgNYX1I2WXaUaXg97W9JCkFyth85TzBWKDBTyhLfenrukS/kyu54A==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.3.2",
         "tslib": "^2.5.0"
@@ -1149,7 +1078,6 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.11.tgz",
       "integrity": "sha512-CaR1dciSSGKttjhcefpytYjsfI/Yd5mqL8am4wfmyFCDxSiPsvnEWHl8UjM/RbcAjX0klt+CeIKPSHEc0wGvJA==",
-      "dev": true,
       "dependencies": {
         "@smithy/property-provider": "^2.0.9",
         "@smithy/shared-ini-file-loader": "^2.0.10",
@@ -1164,7 +1092,6 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.4.tgz",
       "integrity": "sha512-8Rw/AusvWDyC6SK8esAcVBeTlQHf94NMFv805suFUJCQ2gwlh0oLDNh+6s2MDOrxcjvLxjjzv1mytM0Mt+0cPQ==",
-      "dev": true,
       "dependencies": {
         "@smithy/abort-controller": "^2.0.8",
         "@smithy/protocol-http": "^3.0.4",
@@ -1180,7 +1107,6 @@
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.9.tgz",
       "integrity": "sha512-25pPZ8f8DeRwYI5wbPRZaoMoR+3vrw8DwbA0TjP+GsdiB2KxScndr4HQehiJ5+WJ0giOTWhLz0bd+7Djv1qpUQ==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.3.2",
         "tslib": "^2.5.0"
@@ -1193,7 +1119,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.4.tgz",
       "integrity": "sha512-CGfSWk6TRlbwa8YgrSXdn80Yu7pov3EV/h7TSfiCHhq6/LO3WymmqnzgH1f0qV2bdTDipIkTNp5dGCGN3Af/5g==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.3.2",
         "tslib": "^2.5.0"
@@ -1206,7 +1131,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.8.tgz",
       "integrity": "sha512-+vzIMwjC8Saz97/ptPn+IJRCRRZ+pP95ZIWDRqEqZV/a6hiKbaFoMSa2iCKsnKzR696U2JZXrDqMu3e/FD1+2g==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.3.2",
         "@smithy/util-uri-escape": "^2.0.0",
@@ -1220,7 +1144,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.8.tgz",
       "integrity": "sha512-ArbanNuR7O/MmTd90ZqhDqGOPPDYmxx3huHxD+R3cuCnazcK/1tGQA+SnnR5307T7ZRb5WTpB6qBggERuibVSA==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.3.2",
         "tslib": "^2.5.0"
@@ -1233,7 +1156,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.1.tgz",
       "integrity": "sha512-QHa9+t+v4s0cMuDCcbjIJN67mNZ42/+fc3jKe8P6ZMPXZl5ksKk6a8vhZ/m494GZng5eFTc3OePv+NF9cG83yg==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.3.2"
       },
@@ -1245,7 +1167,6 @@
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.10.tgz",
       "integrity": "sha512-jWASteSezRKohJ7GdA7pHDvmr7Q7tw3b5mu3xLHIkZy/ICftJ+O7aqNaF8wklhI7UNFoQ7flFRM3Rd0KA+1BbQ==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.3.2",
         "tslib": "^2.5.0"
@@ -1258,7 +1179,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.8.tgz",
       "integrity": "sha512-qrtiYMzaLlQ5HSJOaFwnyTQ3JLjmPY+3+pr9IBDpCVM6YtVj22cBLVB9bPOiZMIpkdI7ZRdxLBFlIjh5CO1Bhw==",
-      "dev": true,
       "dependencies": {
         "@smithy/eventstream-codec": "^2.0.8",
         "@smithy/is-array-buffer": "^2.0.0",
@@ -1277,7 +1197,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.5.tgz",
       "integrity": "sha512-7S865uKzsxApM8W8Q6zkij7tcUFgaG8PuADMFdMt1yL/ku3d0+s6Zwrg3N7iXCPM08Gu/mf0BIfTXIu/9i450Q==",
-      "dev": true,
       "dependencies": {
         "@smithy/middleware-stack": "^2.0.1",
         "@smithy/types": "^2.3.2",
@@ -1292,7 +1211,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.3.2.tgz",
       "integrity": "sha512-iH0cdKi7HQlzfAM3w2shFk/qZYKAqJWswtpmQpPtlruF+uFZeGEpMJjgDRyhWiddfVM4e2oP4nMaOBsMy6lXgg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1304,7 +1222,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.8.tgz",
       "integrity": "sha512-wQw7j004ScCrBRJ+oNPXlLE9mtofxyadSZ9D8ov/rHkyurS7z1HTNuyaGRj6OvKsEk0SVQsuY0C9+EfM75XTkw==",
-      "dev": true,
       "dependencies": {
         "@smithy/querystring-parser": "^2.0.8",
         "@smithy/types": "^2.3.2",
@@ -1315,7 +1232,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.0.tgz",
       "integrity": "sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==",
-      "dev": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
@@ -1328,7 +1244,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
       "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       }
@@ -1337,7 +1252,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
       "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1349,7 +1263,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
       "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
-      "dev": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^2.0.0",
         "tslib": "^2.5.0"
@@ -1362,7 +1275,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
       "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1374,7 +1286,6 @@
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.9.tgz",
       "integrity": "sha512-JONLJVQWT8165XoSV36ERn3SVlZLJJ4D6IeGsCSePv65Uxa93pzSLE0UMSR9Jwm4zix7rst9AS8W5QIypZWP8Q==",
-      "dev": true,
       "dependencies": {
         "@smithy/property-provider": "^2.0.9",
         "@smithy/smithy-client": "^2.1.5",
@@ -1390,7 +1301,6 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.11.tgz",
       "integrity": "sha512-tmqjNsfj+bgZN6jXBe6efZnukzILA7BUytHkzqikuRLNtR+0VVchQHvawD0w6vManh76rO81ydhioe7i4oBzuA==",
-      "dev": true,
       "dependencies": {
         "@smithy/config-resolver": "^2.0.9",
         "@smithy/credential-provider-imds": "^2.0.11",
@@ -1408,7 +1318,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
       "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1420,7 +1329,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.1.tgz",
       "integrity": "sha512-LnsBMi0Mg3gfz/TpNGLv2Jjcz2ra1OX5HR/4IaCepIYmtPQzqMWDdhX/XTW1LS8OZ0xbQuyQPcHkQ+2XkhWOVQ==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.3.2",
         "tslib": "^2.5.0"
@@ -1433,7 +1341,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.1.tgz",
       "integrity": "sha512-naj4X0IafJ9yJnVJ58QgSMkCNLjyQOnyrnKh/T0f+0UOUxJiT8vuFn/hS7B/pNqbo2STY7PyJ4J4f+5YqxwNtA==",
-      "dev": true,
       "dependencies": {
         "@smithy/service-error-classification": "^2.0.1",
         "@smithy/types": "^2.3.2",
@@ -1447,7 +1354,6 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.11.tgz",
       "integrity": "sha512-2MeWfqSpZKdmEJ+tH8CJQSgzLWhH5cmdE24X7JB0hiamXrOmswWGGuPvyj/9sQCTclo57pNxLR2p7KrP8Ahiyg==",
-      "dev": true,
       "dependencies": {
         "@smithy/fetch-http-handler": "^2.1.4",
         "@smithy/node-http-handler": "^2.1.4",
@@ -1466,7 +1372,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
       "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1478,7 +1383,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
       "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
-      "dev": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
@@ -1491,7 +1395,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.8.tgz",
       "integrity": "sha512-t9yaoofNhdEhNlyDeV5al/JJEFJ62HIQBGktgCUE63MvKn6imnbkh1qISsYMyMYVLwhWCpZ3Xa3R1LA+SnWcng==",
-      "dev": true,
       "dependencies": {
         "@smithy/abort-controller": "^2.0.8",
         "@smithy/types": "^2.3.2",
@@ -1680,8 +1583,7 @@
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "dev": true
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2156,7 +2058,6 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
       "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-      "dev": true,
       "funding": [
         {
           "type": "paypal",
@@ -3258,8 +3159,7 @@
     "node_modules/strnum": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-      "dev": true
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "node_modules/supports-color": {
       "version": "3.2.3",
@@ -3301,8 +3201,7 @@
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -3369,7 +3268,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -3610,7 +3508,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
       "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
-      "dev": true,
       "requires": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -3620,8 +3517,7 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -3629,7 +3525,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz",
       "integrity": "sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==",
-      "dev": true,
       "requires": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -3639,8 +3534,7 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -3648,7 +3542,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
       "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-      "dev": true,
       "requires": {
         "tslib": "^1.11.1"
       },
@@ -3656,8 +3549,7 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -3665,7 +3557,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-3.0.0.tgz",
       "integrity": "sha512-NJth5c997GLHs6nOYTzFKTbYdMNA6/1XlKVgnZoaZcQ7z7UJlOgj2JdbHE8tiYLS3fzXNCguct77SPGat2raSw==",
-      "dev": true,
       "requires": {
         "@aws-crypto/ie11-detection": "^3.0.0",
         "@aws-crypto/supports-web-crypto": "^3.0.0",
@@ -3679,8 +3570,7 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -3688,7 +3578,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
       "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-      "dev": true,
       "requires": {
         "@aws-crypto/ie11-detection": "^3.0.0",
         "@aws-crypto/sha256-js": "^3.0.0",
@@ -3703,8 +3592,7 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -3712,7 +3600,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
       "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-      "dev": true,
       "requires": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -3722,8 +3609,7 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -3731,7 +3617,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
       "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-      "dev": true,
       "requires": {
         "tslib": "^1.11.1"
       },
@@ -3739,8 +3624,7 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -3748,7 +3632,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
       "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -3758,8 +3641,7 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -3767,7 +3649,6 @@
       "version": "3.414.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-athena/-/client-athena-3.414.0.tgz",
       "integrity": "sha512-0UpjwvntiVxJ9s85UdJeQ5Hx6Y/6A59dGtI6GOOrm0vTaKIKhGJ6MU1qaC2O4EuANm6hliLxMTA3e7sIEUAKww==",
-      "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -3813,7 +3694,6 @@
       "version": "3.414.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.414.0.tgz",
       "integrity": "sha512-uEag2GPuuxWmnzOxUhAy0EYo3LW3u/UyCw1IxU3zkaTRQnD6TZ07kjv3Q6Zytqt82yKzJPZInzNNRdtGJdyxbw==",
-      "dev": true,
       "requires": {
         "@aws-crypto/sha1-browser": "3.0.0",
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -3876,7 +3756,6 @@
       "version": "3.414.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.414.0.tgz",
       "integrity": "sha512-GvRwQ7wA3edzsQEKS70ZPhkOUZ62PAiXasjp6GxrsADEb8sV1z4FxXNl9Un/7fQxKkh9QYaK1Wu1PmhLi9MLMg==",
-      "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -3918,7 +3797,6 @@
       "version": "3.414.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.414.0.tgz",
       "integrity": "sha512-xeYH3si6Imp1EWolWn1zuxJJu2AXKwXl1HDftQULwC5AWkm1mNFbXYSJN4hQul1IM+kn+JTRB0XRHByQkKhe+Q==",
-      "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -3964,7 +3842,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.413.0.tgz",
       "integrity": "sha512-yeMOkfG20/RlzfPMtQuDB647AcPEvFEVYOWZzAWVJfldYQ5ybKr0d7sBkgG9sdAzGkK3Aw9dE4rigYI8EIqc1Q==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/property-provider": "^2.0.0",
@@ -3976,7 +3853,6 @@
       "version": "3.414.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.414.0.tgz",
       "integrity": "sha512-rlpLLx70roJL/t40opWC96LbIASejdMbRlgSCRpK8b/hKngYDe5A7SRVacaw08vYrAywxRiybxpQOwOt9b++rA==",
-      "dev": true,
       "requires": {
         "@aws-sdk/credential-provider-env": "3.413.0",
         "@aws-sdk/credential-provider-process": "3.413.0",
@@ -3994,7 +3870,6 @@
       "version": "3.414.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.414.0.tgz",
       "integrity": "sha512-xlkcOUKeGHInxWKKrZKIPSBCUL/ozyCldJBjmMKEj7ZmBAEiDcjpMe3pZ//LibMkCSy0b/7jtyQBE/eaIT2o0A==",
-      "dev": true,
       "requires": {
         "@aws-sdk/credential-provider-env": "3.413.0",
         "@aws-sdk/credential-provider-ini": "3.414.0",
@@ -4013,7 +3888,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.413.0.tgz",
       "integrity": "sha512-GFJdgS14GzJ1wc2DEnS44Z/34iBZ05CAkvDsLN2CMwcDgH4eZuif9/x0lwzIJBK3xVFHzYUeVvEzsqRPbCHRsw==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/property-provider": "^2.0.0",
@@ -4026,7 +3900,6 @@
       "version": "3.414.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.414.0.tgz",
       "integrity": "sha512-w9g2hlkZn7WekWICRqk+L33py7KrjYMFryVpkKXOx2pjDchCfZDr6pL1ml782GZ0L3qsob4SbNpbtp13JprnWQ==",
-      "dev": true,
       "requires": {
         "@aws-sdk/client-sso": "3.414.0",
         "@aws-sdk/token-providers": "3.413.0",
@@ -4041,7 +3914,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.413.0.tgz",
       "integrity": "sha512-5cdA1Iq9JeEHtg59ERV9fdMQ7cS0JF6gH/BWA7HYEUGdSVPXCuwyEggPtG64QgpNU7SmxH+QdDG+Ldxz09ycIA==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/property-provider": "^2.0.0",
@@ -4053,7 +3925,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.413.0.tgz",
       "integrity": "sha512-hHfaKg4rbpdgB6iMNLW/ubAJFsPFMNOV/hHpZ7BJVdA05fW6Zj6es+TSr7DM3j4Dv49ckhWY0P+JrSkM3FXXpg==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.413.0",
         "@aws-sdk/util-arn-parser": "3.310.0",
@@ -4068,7 +3939,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.413.0.tgz",
       "integrity": "sha512-14L4Fit+3EEVZNHCZKxua4vCrh+dGaaDfC5Ng3A8nILAqCsG2dhbDbUOwbnAaM8MCEVOgZS/NwUUlLA9AZfKgQ==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/protocol-http": "^3.0.3",
@@ -4080,7 +3950,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.413.0.tgz",
       "integrity": "sha512-xb7WIxmyCQoBCnzaN+Widuan0PbNxYegKLOW4XheYz/v7lBEttIcGMu+OIAIQs3KlTb3dx8jqjSj2rMNnru8MQ==",
-      "dev": true,
       "requires": {
         "@aws-crypto/crc32": "3.0.0",
         "@aws-crypto/crc32c": "3.0.0",
@@ -4096,7 +3965,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.413.0.tgz",
       "integrity": "sha512-r9PQx468EzPHo9wRzZLfgROpKtVdbkteMrdhsuM12bifVHjU1OHr7yfhc1OdWv39X8Xiv6F8n5r+RBQEM0S6+g==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/protocol-http": "^3.0.3",
@@ -4108,7 +3976,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.413.0.tgz",
       "integrity": "sha512-JecF1O1Lm8ZZtCgXHwJm0ZysVf8K0Z8DbrNMJfYkyfsP3CYuQNJbmjrehyRl7aCuxMJ16EUGdXgoP1M8TImLpA==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/types": "^2.3.1",
@@ -4119,7 +3986,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.413.0.tgz",
       "integrity": "sha512-jqcXDubcKvoqBy+kkEa0WoNjG6SveDeyNy+gdGnTV+DEtYjkcHrHJei4q0W5zFl0mzc+dP+z8tJF44rv95ZY3Q==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/types": "^2.3.1",
@@ -4130,7 +3996,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.413.0.tgz",
       "integrity": "sha512-C6k0IKJk/A4/VBGwUjxEPG+WOjjnmWAZVRBUzaeM7PqRh+g5rLcuIV356ntV3pREVxyiSTePTYVYIHU9YXkLKQ==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/protocol-http": "^3.0.3",
@@ -4142,7 +4007,6 @@
       "version": "3.414.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.414.0.tgz",
       "integrity": "sha512-IKTiYMWN/2HZtgBinrDOGq+gKYkM9h477AqVr7EXSfll+gM9phwJKEitgxje7IaCi8ViQcFKtTRly3eCLX6GIA==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.413.0",
         "@aws-sdk/util-arn-parser": "3.310.0",
@@ -4156,7 +4020,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.413.0.tgz",
       "integrity": "sha512-t0u//JUyaEZRVnH5q+Ur3tWnuyIsTdwA0XOdDCZXcSlLYzGp2MI/tScLjn9IydRrceIFpFfmbjk4Nf/Q6TeBTQ==",
-      "dev": true,
       "requires": {
         "@aws-sdk/middleware-signing": "3.413.0",
         "@aws-sdk/types": "3.413.0",
@@ -4168,7 +4031,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.413.0.tgz",
       "integrity": "sha512-QFEnVvIKYPCermM+ESxEztgUgXzGSKpnPnohMYNvSZySqmOLu/4VvxiZbRO/BX9J3ZHcUgaw4vKm5VBZRrycxw==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/property-provider": "^2.0.0",
@@ -4183,7 +4045,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.413.0.tgz",
       "integrity": "sha512-MQNksEnhjObNLgE2zRd0OltdijQuqHaArP3FygtdeE2bCXc/D5mCpUX8fgDC5grQIBNdRdaar2YL62UxFsHWrw==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/types": "^2.3.1",
@@ -4194,7 +4055,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.413.0.tgz",
       "integrity": "sha512-eVMJyeWxNBqerhfD+sE9sTjDtwQiECrfU6wpUQP5fGPhJD2cVVZPxuTuJGDZCu/4k/V61dF85IYlsPUNLdVQ6w==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.413.0",
         "@aws-sdk/util-endpoints": "3.413.0",
@@ -4207,7 +4067,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.413.0.tgz",
       "integrity": "sha512-h90e6yyOhvoc+1F5vFk3C5mxwB8RSDEMKTO/fxexyur94seczZ1yxyYkTMZv30oc9RUiToABlHNrh/wxL7TZPQ==",
-      "dev": true,
       "requires": {
         "@smithy/node-config-provider": "^2.0.10",
         "@smithy/types": "^2.3.1",
@@ -4220,7 +4079,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.413.0.tgz",
       "integrity": "sha512-4USefVS5HPeJ8Yx0j6l84837adWGTifGpnltD+4mIgvpGp/hW3EkwvJko6i4cnLbeY8D2+8XvgT9YN1LUhvFmg==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/protocol-http": "^3.0.3",
@@ -4233,7 +4091,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.413.0.tgz",
       "integrity": "sha512-NfP1Ib9LAWVLMTOa/1aJwt4TRrlRrNyukCpVZGfNaMnNNEoP5Rakdbcs8KFVHe/MJzU+GdKVzxQ4TgRkLOGTrA==",
-      "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -4276,7 +4133,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.413.0.tgz",
       "integrity": "sha512-j1xib0f/TazIFc5ySIKOlT1ujntRbaoG4LJFeEezz4ji03/wSJMI8Vi4KjzpBp8J1tTu0oRDnsxRIGixsUBeYQ==",
-      "dev": true,
       "requires": {
         "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
@@ -4286,7 +4142,6 @@
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.310.0.tgz",
       "integrity": "sha512-jL8509owp/xB9+Or0pvn3Fe+b94qfklc2yPowZZIFAkFcCSIdkIglz18cPDWnYAcy9JGewpMS1COXKIUhZkJsA==",
-      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -4295,7 +4150,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.413.0.tgz",
       "integrity": "sha512-VAwr7cITNb1L6/2XUPIbCOuhKGm0VtKCRblurrfUF2bxqG/wtuw/2Fm4ahYJPyxklOSXAMSq+RHdFWcir0YB/g==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.413.0",
         "tslib": "^2.5.0"
@@ -4305,7 +4159,6 @@
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
       "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
-      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -4314,7 +4167,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.413.0.tgz",
       "integrity": "sha512-7j/qWcRO2OBZBre2fC6V6M0PAS9n7k6i+VtofPkkhxC2DZszLJElqnooF9hGmVGYK3zR47Np4WjURXKIEZclWg==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/types": "^2.3.1",
@@ -4326,7 +4178,6 @@
       "version": "3.413.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.413.0.tgz",
       "integrity": "sha512-vHm9TVZIzfWMeDvdmoOky6VarqOt8Pr68CESHN0jyuO6XbhCDnr9rpaXiBhbSR+N1Qm7R/AfJgAhQyTMu2G1OA==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.413.0",
         "@smithy/node-config-provider": "^2.0.10",
@@ -4338,7 +4189,6 @@
       "version": "3.259.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
       "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
-      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -4347,7 +4197,6 @@
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.310.0.tgz",
       "integrity": "sha512-TqELu4mOuSIKQCqj63fGVs86Yh+vBx5nHRpWKNUNhB2nPTpfbziTs5c1X358be3peVWA4wPxW7Nt53KIg1tnNw==",
-      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -4356,7 +4205,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.8.tgz",
       "integrity": "sha512-2SOdVj5y0zE37Y9scSXoizoxgi6mgnDabi7a/SOfhl0p+50I0rIkuJTfyAuTPDtQ7e5dD6tSZPCLB3c/YM6Zig==",
-      "dev": true,
       "requires": {
         "@smithy/types": "^2.3.2",
         "tslib": "^2.5.0"
@@ -4366,7 +4214,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-2.0.0.tgz",
       "integrity": "sha512-k+J4GHJsMSAIQPChGBrjEmGS+WbPonCXesoqP9fynIqjn7rdOThdH8FAeCmokP9mxTYKQAKoHCLPzNlm6gh7Wg==",
-      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -4375,7 +4222,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-2.0.0.tgz",
       "integrity": "sha512-HM8V2Rp1y8+1343tkZUKZllFhEQPNmpNdgFAncbTsxkZ18/gqjk23XXv3qGyXWp412f3o43ZZ1UZHVcHrpRnCQ==",
-      "dev": true,
       "requires": {
         "@smithy/util-base64": "^2.0.0",
         "tslib": "^2.5.0"
@@ -4385,7 +4231,6 @@
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.9.tgz",
       "integrity": "sha512-QBkGPLUqyPmis9Erz8v4q5lo/ErnF7+GD5WZHa6JZiXopUPfaaM+B21n8gzS5xCkIXZmnwzNQhObP9xQPu8oqQ==",
-      "dev": true,
       "requires": {
         "@smithy/node-config-provider": "^2.0.11",
         "@smithy/types": "^2.3.2",
@@ -4398,7 +4243,6 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.11.tgz",
       "integrity": "sha512-uJJs8dnM5iXkn8a2GaKvlKMhcOJ+oJPYqY9gY3CM/EieCVObIDjxUtR/g8lU/k/A+OauA78GzScAfulmFjPOYA==",
-      "dev": true,
       "requires": {
         "@smithy/node-config-provider": "^2.0.11",
         "@smithy/property-provider": "^2.0.9",
@@ -4411,7 +4255,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.8.tgz",
       "integrity": "sha512-onO4to8ujCKn4m5XagReT9Nc6FlNG5vveuvjp1H7AtaG7njdet1LOl6/jmUOkskF2C/w+9jNw3r9Ak+ghOvN0A==",
-      "dev": true,
       "requires": {
         "@aws-crypto/crc32": "3.0.0",
         "@smithy/types": "^2.3.2",
@@ -4423,7 +4266,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.0.8.tgz",
       "integrity": "sha512-/RGlkKUnC0sd+xKBKH/2APSBRmVMZTeLOKZMhrZmrO+ONoU+DwyMr/RLJ6WnmBKN+2ebjffM4pcIJTKLNNDD8g==",
-      "dev": true,
       "requires": {
         "@smithy/eventstream-serde-universal": "^2.0.8",
         "@smithy/types": "^2.3.2",
@@ -4434,7 +4276,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.0.8.tgz",
       "integrity": "sha512-EyAEj258eMUv9zcMvBbqrInh2eHRYuiwQAjXDMxZFCyP+JePzQB6O++3wFwjQeRKMFFgZipNgnEXfReII4+NAw==",
-      "dev": true,
       "requires": {
         "@smithy/types": "^2.3.2",
         "tslib": "^2.5.0"
@@ -4444,7 +4285,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.0.8.tgz",
       "integrity": "sha512-FMBatSUSKwh6aguKVJokXfJaV8nqsuCkCZHb9MP9zah0ZF+ohbTLeeed7DQGeTVBueVIVWEzIsShPxtxBv7MMQ==",
-      "dev": true,
       "requires": {
         "@smithy/eventstream-serde-universal": "^2.0.8",
         "@smithy/types": "^2.3.2",
@@ -4455,7 +4295,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.0.8.tgz",
       "integrity": "sha512-6InMXH8BUKoEDa6CAuxR4Gn8Gf2vBfVtjA9A6zDKZClYHT+ANUJS+2EtOBc5wECJJGk4KLn5ajQyrt9MBv5lcw==",
-      "dev": true,
       "requires": {
         "@smithy/eventstream-codec": "^2.0.8",
         "@smithy/types": "^2.3.2",
@@ -4466,7 +4305,6 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.1.4.tgz",
       "integrity": "sha512-SL24M9W5ERByoXaVicRx+bj9GJVujDnPn+QO7GY7adhY0mPGa6DSF58pVKsgIh4r5Tx/k3SWCPlH4BxxSxA/fQ==",
-      "dev": true,
       "requires": {
         "@smithy/protocol-http": "^3.0.4",
         "@smithy/querystring-builder": "^2.0.8",
@@ -4479,7 +4317,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-2.0.8.tgz",
       "integrity": "sha512-IgvRlBMfg/qLg321a59T1yTdEEbaizLrEVsU3DHj65DAO4lFRMF5f+l7vuV+je6m1G9wSD5GQXLturX8qlGb4g==",
-      "dev": true,
       "requires": {
         "@smithy/chunked-blob-reader": "^2.0.0",
         "@smithy/chunked-blob-reader-native": "^2.0.0",
@@ -4491,7 +4328,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.8.tgz",
       "integrity": "sha512-yZL/nmxZzjZV5/QX5JWSgXlt0HxuMTwFO89CS++jOMMPiCMZngf6VYmtNdccs8IIIAMmfQeTzwu07XgUE/Zd3Q==",
-      "dev": true,
       "requires": {
         "@smithy/types": "^2.3.2",
         "@smithy/util-buffer-from": "^2.0.0",
@@ -4503,7 +4339,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-2.0.8.tgz",
       "integrity": "sha512-82zC6I9ZJycbEZH8TVyXyBx9c2ZIPQDgBvM0x5AFPUl/i1AxwKKX+lwYRnzgkF//cYhIIoJaCfJ9mjSMPRGvCQ==",
-      "dev": true,
       "requires": {
         "@smithy/types": "^2.3.2",
         "@smithy/util-utf8": "^2.0.0",
@@ -4514,7 +4349,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.8.tgz",
       "integrity": "sha512-88VOS7W3KzUz/bNRc+Sl/F/CDIasFspEE4G39YZRHIh9YmsXF7GUyVaAKURfMNulTie62ayk6BHC9O0nOBAVgQ==",
-      "dev": true,
       "requires": {
         "@smithy/types": "^2.3.2",
         "tslib": "^2.5.0"
@@ -4524,7 +4358,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
       "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
-      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -4533,7 +4366,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.0.8.tgz",
       "integrity": "sha512-1VVECXEiuJvjXv+mudiaUFKYwgDLOWz5MTTy8RzbrPiU3GiOb3/o5/urdkYpqmgoMfxdvxxOw/Adjv2dV2q2Yg==",
-      "dev": true,
       "requires": {
         "@smithy/types": "^2.3.2",
         "@smithy/util-utf8": "^2.0.0",
@@ -4544,7 +4376,6 @@
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.10.tgz",
       "integrity": "sha512-EGSbysyA4jH0p3xI6G0jdXoj9Iz9GUnAta6aEaHtXm3wVWtenRf80y2TeVvNkVSr5jwKOdSCjKIRI2l1A/oZLA==",
-      "dev": true,
       "requires": {
         "@smithy/protocol-http": "^3.0.4",
         "@smithy/types": "^2.3.2",
@@ -4555,7 +4386,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.8.tgz",
       "integrity": "sha512-yOpogfG2d2V0cbJdAJ6GLAWkNOc9pVsL5hZUfXcxJu408N3CUCsXzIAFF6+70ZKSE+lCfG3GFErcSXv/UfUbjw==",
-      "dev": true,
       "requires": {
         "@smithy/middleware-serde": "^2.0.8",
         "@smithy/types": "^2.3.2",
@@ -4568,7 +4398,6 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.11.tgz",
       "integrity": "sha512-pknfokumZ+wvBERSuKAI2vVr+aK3ZgPiWRg6+0ZG4kKJogBRpPmDGWw+Jht0izS9ZaEbIobNzueIb4wD33JJVg==",
-      "dev": true,
       "requires": {
         "@smithy/node-config-provider": "^2.0.11",
         "@smithy/protocol-http": "^3.0.4",
@@ -4584,7 +4413,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.8.tgz",
       "integrity": "sha512-Is0sm+LiNlgsc0QpstDzifugzL9ehno1wXp109GgBgpnKTK3j+KphiparBDI4hWTtH9/7OUsxuspNqai2yyhcg==",
-      "dev": true,
       "requires": {
         "@smithy/types": "^2.3.2",
         "tslib": "^2.5.0"
@@ -4594,7 +4422,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.1.tgz",
       "integrity": "sha512-UexsfY6/oQZRjTQL56s9AKtMcR60tBNibSgNYX1I2WXaUaXg97W9JCkFyth85TzBWKDBTyhLfenrukS/kyu54A==",
-      "dev": true,
       "requires": {
         "@smithy/types": "^2.3.2",
         "tslib": "^2.5.0"
@@ -4604,7 +4431,6 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.11.tgz",
       "integrity": "sha512-CaR1dciSSGKttjhcefpytYjsfI/Yd5mqL8am4wfmyFCDxSiPsvnEWHl8UjM/RbcAjX0klt+CeIKPSHEc0wGvJA==",
-      "dev": true,
       "requires": {
         "@smithy/property-provider": "^2.0.9",
         "@smithy/shared-ini-file-loader": "^2.0.10",
@@ -4616,7 +4442,6 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.4.tgz",
       "integrity": "sha512-8Rw/AusvWDyC6SK8esAcVBeTlQHf94NMFv805suFUJCQ2gwlh0oLDNh+6s2MDOrxcjvLxjjzv1mytM0Mt+0cPQ==",
-      "dev": true,
       "requires": {
         "@smithy/abort-controller": "^2.0.8",
         "@smithy/protocol-http": "^3.0.4",
@@ -4629,7 +4454,6 @@
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.9.tgz",
       "integrity": "sha512-25pPZ8f8DeRwYI5wbPRZaoMoR+3vrw8DwbA0TjP+GsdiB2KxScndr4HQehiJ5+WJ0giOTWhLz0bd+7Djv1qpUQ==",
-      "dev": true,
       "requires": {
         "@smithy/types": "^2.3.2",
         "tslib": "^2.5.0"
@@ -4639,7 +4463,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.4.tgz",
       "integrity": "sha512-CGfSWk6TRlbwa8YgrSXdn80Yu7pov3EV/h7TSfiCHhq6/LO3WymmqnzgH1f0qV2bdTDipIkTNp5dGCGN3Af/5g==",
-      "dev": true,
       "requires": {
         "@smithy/types": "^2.3.2",
         "tslib": "^2.5.0"
@@ -4649,7 +4472,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.8.tgz",
       "integrity": "sha512-+vzIMwjC8Saz97/ptPn+IJRCRRZ+pP95ZIWDRqEqZV/a6hiKbaFoMSa2iCKsnKzR696U2JZXrDqMu3e/FD1+2g==",
-      "dev": true,
       "requires": {
         "@smithy/types": "^2.3.2",
         "@smithy/util-uri-escape": "^2.0.0",
@@ -4660,7 +4482,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.8.tgz",
       "integrity": "sha512-ArbanNuR7O/MmTd90ZqhDqGOPPDYmxx3huHxD+R3cuCnazcK/1tGQA+SnnR5307T7ZRb5WTpB6qBggERuibVSA==",
-      "dev": true,
       "requires": {
         "@smithy/types": "^2.3.2",
         "tslib": "^2.5.0"
@@ -4670,7 +4491,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.1.tgz",
       "integrity": "sha512-QHa9+t+v4s0cMuDCcbjIJN67mNZ42/+fc3jKe8P6ZMPXZl5ksKk6a8vhZ/m494GZng5eFTc3OePv+NF9cG83yg==",
-      "dev": true,
       "requires": {
         "@smithy/types": "^2.3.2"
       }
@@ -4679,7 +4499,6 @@
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.10.tgz",
       "integrity": "sha512-jWASteSezRKohJ7GdA7pHDvmr7Q7tw3b5mu3xLHIkZy/ICftJ+O7aqNaF8wklhI7UNFoQ7flFRM3Rd0KA+1BbQ==",
-      "dev": true,
       "requires": {
         "@smithy/types": "^2.3.2",
         "tslib": "^2.5.0"
@@ -4689,7 +4508,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.8.tgz",
       "integrity": "sha512-qrtiYMzaLlQ5HSJOaFwnyTQ3JLjmPY+3+pr9IBDpCVM6YtVj22cBLVB9bPOiZMIpkdI7ZRdxLBFlIjh5CO1Bhw==",
-      "dev": true,
       "requires": {
         "@smithy/eventstream-codec": "^2.0.8",
         "@smithy/is-array-buffer": "^2.0.0",
@@ -4705,7 +4523,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.5.tgz",
       "integrity": "sha512-7S865uKzsxApM8W8Q6zkij7tcUFgaG8PuADMFdMt1yL/ku3d0+s6Zwrg3N7iXCPM08Gu/mf0BIfTXIu/9i450Q==",
-      "dev": true,
       "requires": {
         "@smithy/middleware-stack": "^2.0.1",
         "@smithy/types": "^2.3.2",
@@ -4717,7 +4534,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.3.2.tgz",
       "integrity": "sha512-iH0cdKi7HQlzfAM3w2shFk/qZYKAqJWswtpmQpPtlruF+uFZeGEpMJjgDRyhWiddfVM4e2oP4nMaOBsMy6lXgg==",
-      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -4726,7 +4542,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.8.tgz",
       "integrity": "sha512-wQw7j004ScCrBRJ+oNPXlLE9mtofxyadSZ9D8ov/rHkyurS7z1HTNuyaGRj6OvKsEk0SVQsuY0C9+EfM75XTkw==",
-      "dev": true,
       "requires": {
         "@smithy/querystring-parser": "^2.0.8",
         "@smithy/types": "^2.3.2",
@@ -4737,7 +4552,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.0.tgz",
       "integrity": "sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==",
-      "dev": true,
       "requires": {
         "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
@@ -4747,7 +4561,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
       "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
-      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -4756,7 +4569,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
       "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
-      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -4765,7 +4577,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
       "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
-      "dev": true,
       "requires": {
         "@smithy/is-array-buffer": "^2.0.0",
         "tslib": "^2.5.0"
@@ -4775,7 +4586,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
       "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
-      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -4784,7 +4594,6 @@
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.9.tgz",
       "integrity": "sha512-JONLJVQWT8165XoSV36ERn3SVlZLJJ4D6IeGsCSePv65Uxa93pzSLE0UMSR9Jwm4zix7rst9AS8W5QIypZWP8Q==",
-      "dev": true,
       "requires": {
         "@smithy/property-provider": "^2.0.9",
         "@smithy/smithy-client": "^2.1.5",
@@ -4797,7 +4606,6 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.11.tgz",
       "integrity": "sha512-tmqjNsfj+bgZN6jXBe6efZnukzILA7BUytHkzqikuRLNtR+0VVchQHvawD0w6vManh76rO81ydhioe7i4oBzuA==",
-      "dev": true,
       "requires": {
         "@smithy/config-resolver": "^2.0.9",
         "@smithy/credential-provider-imds": "^2.0.11",
@@ -4812,7 +4620,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
       "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
-      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -4821,7 +4628,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.1.tgz",
       "integrity": "sha512-LnsBMi0Mg3gfz/TpNGLv2Jjcz2ra1OX5HR/4IaCepIYmtPQzqMWDdhX/XTW1LS8OZ0xbQuyQPcHkQ+2XkhWOVQ==",
-      "dev": true,
       "requires": {
         "@smithy/types": "^2.3.2",
         "tslib": "^2.5.0"
@@ -4831,7 +4637,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.1.tgz",
       "integrity": "sha512-naj4X0IafJ9yJnVJ58QgSMkCNLjyQOnyrnKh/T0f+0UOUxJiT8vuFn/hS7B/pNqbo2STY7PyJ4J4f+5YqxwNtA==",
-      "dev": true,
       "requires": {
         "@smithy/service-error-classification": "^2.0.1",
         "@smithy/types": "^2.3.2",
@@ -4842,7 +4647,6 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.11.tgz",
       "integrity": "sha512-2MeWfqSpZKdmEJ+tH8CJQSgzLWhH5cmdE24X7JB0hiamXrOmswWGGuPvyj/9sQCTclo57pNxLR2p7KrP8Ahiyg==",
-      "dev": true,
       "requires": {
         "@smithy/fetch-http-handler": "^2.1.4",
         "@smithy/node-http-handler": "^2.1.4",
@@ -4858,7 +4662,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
       "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
-      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -4867,7 +4670,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
       "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
-      "dev": true,
       "requires": {
         "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
@@ -4877,7 +4679,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.8.tgz",
       "integrity": "sha512-t9yaoofNhdEhNlyDeV5al/JJEFJ62HIQBGktgCUE63MvKn6imnbkh1qISsYMyMYVLwhWCpZ3Xa3R1LA+SnWcng==",
-      "dev": true,
       "requires": {
         "@smithy/abort-controller": "^2.0.8",
         "@smithy/types": "^2.3.2",
@@ -5029,8 +4830,7 @@
     "bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "dev": true
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -5389,7 +5189,6 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
       "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-      "dev": true,
       "requires": {
         "strnum": "^1.0.5"
       }
@@ -6201,8 +6000,7 @@
     "strnum": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-      "dev": true
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "supports-color": {
       "version": "3.2.3",
@@ -6235,8 +6033,7 @@
     "tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -6287,8 +6084,7 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,6 @@
   },
   "homepage": "https://github.com/sr-26/athena-express-plus#readme",
   "devDependencies": {
-    "@aws-sdk/client-athena": "^3.414.0",
-    "@aws-sdk/client-s3": "^3.414.0",
     "chai": "^4.2.0",
     "coveralls": "^3.0.11",
     "istanbul": "^0.4.5",
@@ -56,6 +54,8 @@
     "mocha-lcov-reporter": "^1.3.0"
   },
   "dependencies": {
+    "@aws-sdk/client-athena": "^3.414.0",
+    "@aws-sdk/client-s3": "^3.414.0",
     "csvtojson": "^2.0.10"
   }
 }


### PR DESCRIPTION
Fixes #26.

Also updates the `version` in `package-lock.json`, which had not been updated since `8.0.5` (was automatically changed by running `npm install`).